### PR TITLE
feat: verify YouTube video category

### DIFF
--- a/content.js
+++ b/content.js
@@ -5,13 +5,27 @@ console.log('Studify: Content script loaded');
 
 // Function to check if video is educational
 function isEducationalVideo() {
-  // This is a placeholder - we'll implement the actual logic later
-  // to read video category from YouTube's page source
   console.log('Studify: Checking video category...');
-  
-  // For now, return true to allow all videos
-  // Later we'll implement the actual category detection
-  return true;
+
+  let category = null;
+
+  const genreMeta = document.querySelector('meta[itemprop="genre"]');
+  if (genreMeta) {
+    category = genreMeta.getAttribute('content');
+  } else if (
+    window.ytInitialPlayerResponse &&
+    window.ytInitialPlayerResponse.microformat &&
+    window.ytInitialPlayerResponse.microformat.playerMicroformatRenderer &&
+    window.ytInitialPlayerResponse.microformat.playerMicroformatRenderer.category
+  ) {
+    category =
+      window.ytInitialPlayerResponse.microformat.playerMicroformatRenderer
+        .category;
+  }
+
+  console.log('Studify: Detected category:', category);
+
+  return category === 'Education';
 }
 
 // Function to block the page if video is not educational


### PR DESCRIPTION
## Summary
- detect YouTube video category via meta tag or initial player response
- allow playback only when category is "Education"
- trigger blocking for non-educational or missing categories

## Testing
- `node --check content.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a036a9850c83239775789e87390dc1