### PR TITLE
feat: add browsing mode gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Studify helps students stay focused on learning by automatically filtering YouTu
 - **Smart Filtering**: Only allows educational content
 - **User-Friendly Blocking**: Clean, informative blocking page with navigation options
 - **Real-Time Status**: Popup interface showing extension status
+- **Intent Check**: Full‑screen prompt when opening YouTube asks whether you're studying or browsing and for how long. Browsing requires typing *"I am sure I am not procrastinating"* and temporarily disables filtering.
 
 ## 📁 File Structure
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     {
       "matches": ["https://www.youtube.com/*"],
       "js": ["content.js"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ],
   "action": {


### PR DESCRIPTION
## Summary
- prompt users with a full-screen overlay to choose study or browse when YouTube opens
- require exact phrase confirmation for browsing and temporarily disable filtering
- start content script earlier in page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6af25b23c832392b9481094730c43