### PR TITLE
feat: add browsing mode gate with modern UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Studify helps students stay focused on learning by automatically filtering YouTu
 - **Smart Filtering**: Only allows educational content
 - **User-Friendly Blocking**: Clean, informative blocking page with navigation options
 - **Real-Time Status**: Popup interface showing extension status
+- **Intent Check**: Full‑screen prompt when opening YouTube asks whether you're studying or browsing and for how long (using preset durations). Browsing requires typing *"I am sure I am not procrastinating"* and temporarily disables filtering, while study sessions persist for the chosen time even across reloads.
 
 ## 📁 File Structure
 

--- a/content.js
+++ b/content.js
@@ -144,6 +144,11 @@ function showPurposeOverlay() {
           }
           const disabledUntil = Date.now() + minutes * 60 * 1000;
           localStorage.setItem(DISABLED_UNTIL_KEY, String(disabledUntil));
+          try {
+            if (chrome && chrome.storage && chrome.storage.local) {
+              chrome.storage.local.set({ [DISABLED_UNTIL_KEY]: String(disabledUntil) });
+            }
+          } catch (e) {}
           overlay.remove();
           resolve('browse');
         } else {
@@ -556,13 +561,29 @@ function setupSmartNavigationMonitoring() {
 async function init() {
   const disabledUntil = parseInt(localStorage.getItem(DISABLED_UNTIL_KEY) || '0', 10);
   if (Date.now() < disabledUntil) {
+    try {
+      if (chrome && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.set({ [DISABLED_UNTIL_KEY]: String(disabledUntil) });
+      }
+    } catch (e) {}
     const remaining = disabledUntil - Date.now();
     console.log('Studify: Extension paused for browsing mode');
     setTimeout(() => {
+      try {
+        if (chrome && chrome.storage && chrome.storage.local) {
+          chrome.storage.local.remove(DISABLED_UNTIL_KEY);
+        }
+      } catch (e) {}
       localStorage.removeItem(DISABLED_UNTIL_KEY);
       window.location.reload();
     }, remaining);
     return;
+  } else {
+    try {
+      if (chrome && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.remove(DISABLED_UNTIL_KEY);
+      }
+    } catch (e) {}
   }
 
   const studyUntil = parseInt(localStorage.getItem(STUDY_UNTIL_KEY) || '0', 10);
@@ -575,6 +596,11 @@ async function init() {
       const remaining = disabledUntilNew - Date.now();
       if (remaining > 0) {
         setTimeout(() => {
+          try {
+            if (chrome && chrome.storage && chrome.storage.local) {
+              chrome.storage.local.remove(DISABLED_UNTIL_KEY);
+            }
+          } catch (e) {}
           localStorage.removeItem(DISABLED_UNTIL_KEY);
           window.location.reload();
         }, remaining);

--- a/content.js
+++ b/content.js
@@ -8,6 +8,168 @@ let navigateListener = null;
 let currentVideoId = null;
 let isAnalyzing = false;
 
+const DISABLED_UNTIL_KEY = 'studifyDisabledUntil';
+const STUDY_UNTIL_KEY = 'studifyStudyUntil';
+
+// Prompt the user for their intent and duration before allowing YouTube access
+function showPurposeOverlay() {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.id = 'studify-purpose-overlay';
+    overlay.innerHTML = `
+      <div class="studify-modal">
+        <h1 class="studify-title">What brings you to YouTube?</h1>
+        <div class="studify-choice">
+          <button class="studify-btn" data-mode="study">Study</button>
+          <button class="studify-btn" data-mode="browse">Browse</button>
+        </div>
+      </div>
+    `;
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #studify-purpose-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.6);
+        backdrop-filter: blur(6px);
+        font-family: 'Segoe UI', Roboto, sans-serif;
+      }
+      #studify-purpose-overlay .studify-modal {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 40px 30px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+        text-align: center;
+        max-width: 400px;
+        width: 90%;
+      }
+      #studify-purpose-overlay h1 {
+        margin: 0 0 20px;
+        font-size: 24px;
+        color: #111827;
+      }
+      .studify-choice {
+        display: flex;
+        gap: 16px;
+        justify-content: center;
+      }
+      .studify-btn {
+        flex: 1;
+        padding: 12px 0;
+        font-size: 16px;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        color: #ffffff;
+        transition: background 0.2s;
+      }
+      .studify-btn[data-mode="study"] { background: #22c55e; }
+      .studify-btn[data-mode="study"]:hover { background: #16a34a; }
+      .studify-btn[data-mode="browse"] { background: #3b82f6; }
+      .studify-btn[data-mode="browse"]:hover { background: #2563eb; }
+      .studify-inputs {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .studify-inputs input,
+      .studify-inputs select {
+        padding: 10px;
+        font-size: 16px;
+        border: 1px solid #cbd5e1;
+        border-radius: 6px;
+      }
+      .studify-error {
+        color: #ef4444;
+        font-size: 14px;
+      }
+      .studify-start-btn {
+        padding: 12px;
+        background: #6366f1;
+        color: #ffffff;
+        border: none;
+        border-radius: 8px;
+        font-size: 16px;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+      .studify-start-btn:hover { background: #4f46e5; }
+    `;
+    overlay.appendChild(style);
+
+    function askDuration(mode) {
+      const modal = overlay.querySelector('.studify-modal');
+      const options = mode === 'browse'
+        ? [5, 10, 15, 30, 45, 60]
+        : [30, 60, 120, 180, 240];
+      const formatLabel = (m) => {
+        if (m % 60 === 0) {
+          const h = m / 60;
+          return `${h} hour${h > 1 ? 's' : ''}`;
+        }
+        return `${m} minutes`;
+      };
+      const selectHtml = options
+        .map((m) => `<option value="${m}">${formatLabel(m)}</option>`)
+        .join('');
+
+      modal.innerHTML = `
+        <h1 class="studify-title">How long will you ${mode}?</h1>
+        <div class="studify-inputs">
+          <select id="studify-duration">${selectHtml}</select>
+          ${mode === 'browse'
+            ? '<input id="studify-confirm" type="text" placeholder="Type: I am sure I am not procrastinating">'
+            : ''}
+          <button class="studify-start-btn">Start</button>
+          <div class="studify-error" style="display:none;">Incorrect confirmation phrase</div>
+        </div>
+      `;
+
+      const errorEl = modal.querySelector('.studify-error');
+      const startBtn = modal.querySelector('.studify-start-btn');
+      startBtn.addEventListener('click', () => {
+        errorEl.style.display = 'none';
+        const minutes = parseInt(document.getElementById('studify-duration').value, 10);
+        if (isNaN(minutes) || minutes <= 0) return;
+        if (mode === 'browse') {
+          const confirmation = document.getElementById('studify-confirm').value.trim();
+          if (confirmation !== 'I am sure I am not procrastinating') {
+            errorEl.style.display = 'block';
+            return;
+          }
+          const disabledUntil = Date.now() + minutes * 60 * 1000;
+          localStorage.setItem(DISABLED_UNTIL_KEY, String(disabledUntil));
+          overlay.remove();
+          resolve('browse');
+        } else {
+          const studyUntil = Date.now() + minutes * 60 * 1000;
+          localStorage.setItem(STUDY_UNTIL_KEY, String(studyUntil));
+          overlay.remove();
+          resolve('study');
+        }
+      });
+
+      if (mode === 'browse') {
+        const confirmInput = document.getElementById('studify-confirm');
+        confirmInput.addEventListener('input', () => {
+          errorEl.style.display = 'none';
+        });
+      }
+    }
+
+    overlay.querySelectorAll('.studify-btn').forEach((btn) => {
+      btn.addEventListener('click', () => askDuration(btn.dataset.mode));
+    });
+
+    (document.body || document.documentElement).appendChild(overlay);
+  });
+}
+
 // Function to check if we're on a YouTube watch page
 function isYouTubeWatchPage() {
   const currentUrl = window.location.href;
@@ -110,40 +272,61 @@ async function isEducationalVideo() {
 // Function to block the page if video is not educational
 function blockPage() {
   console.log('Studify: Blocking non-educational content');
-  
-  // Clear the page content
+
   document.body.innerHTML = `
-    <div style="
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-      font-family: Arial, sans-serif;
-      text-align: center;
-      background-color: #f8f9fa;
-    ">
-      <h1 style="color: #dc3545; margin-bottom: 20px;"> Access Blocked</h1>
-      <p style="font-size: 18px; color: #6c757d; margin-bottom: 30px;">
-        This YouTube video is not categorized as educational content.
-      </p>
-      <p style="font-size: 16px; color: #6c757d;">
-        Studify only allows educational videos to help you stay focused on learning.
-      </p>
-      <button id="studify-go-back-btn" style="
-        background-color: #007bff;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 6px;
-        font-size: 16px;
-        cursor: pointer;
-        margin-top: 20px;
-      ">
-        Go Back
-      </button>
+    <div id="studify-block-page">
+      <div class="studify-modal">
+        <h1>Access Blocked</h1>
+        <p>This YouTube video is not categorized as educational content.</p>
+        <p>Studify only allows educational videos to help you stay focused on learning.</p>
+        <button id="studify-go-back-btn">Go Back</button>
+      </div>
     </div>
   `;
+
+  const style = document.createElement('style');
+  style.textContent = `
+    #studify-block-page {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', Roboto, sans-serif;
+    }
+    #studify-block-page .studify-modal {
+      background: #1e293b;
+      padding: 40px 30px;
+      border-radius: 12px;
+      text-align: center;
+      max-width: 480px;
+      width: 90%;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    }
+    #studify-block-page h1 {
+      margin-bottom: 16px;
+      color: #f87171;
+    }
+    #studify-block-page p {
+      margin-bottom: 20px;
+      color: #cbd5e1;
+      line-height: 1.4;
+    }
+    #studify-go-back-btn {
+      padding: 12px 24px;
+      border: none;
+      border-radius: 8px;
+      background: #3b82f6;
+      color: #ffffff;
+      font-size: 16px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    #studify-go-back-btn:hover { background: #2563eb; }
+  `;
+  document.head.appendChild(style);
 
   const btn = document.getElementById('studify-go-back-btn');
   if (btn) {
@@ -242,34 +425,57 @@ function isYouTubeShortsPage() {
 
 function blockShortsPage() {
   document.body.innerHTML = `
-    <div style="
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-      font-family: Arial, sans-serif;
-      text-align: center;
-      background-color: #f8f9fa;
-    ">
-      <h1 style="color: #dc3545; margin-bottom: 20px;">Shorts Blocked</h1>
-      <p style="font-size: 16px; color: #6c757d;">
-        Studify blocks YouTube Shorts to keep you focused.
-      </p>
-      <button id="studify-go-back-btn" style="
-        background-color: #007bff;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 6px;
-        font-size: 16px;
-        cursor: pointer;
-        margin-top: 20px;
-      ">
-        Go Back
-      </button>
+    <div id="studify-block-page">
+      <div class="studify-modal">
+        <h1>Shorts Blocked</h1>
+        <p>Studify blocks YouTube Shorts to keep you focused.</p>
+        <button id="studify-go-back-btn">Go Back</button>
+      </div>
     </div>
   `;
+  const style = document.createElement('style');
+  style.textContent = `
+    #studify-block-page {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0f172a;
+      color: #e2e8f0;
+      font-family: 'Segoe UI', Roboto, sans-serif;
+    }
+    #studify-block-page .studify-modal {
+      background: #1e293b;
+      padding: 40px 30px;
+      border-radius: 12px;
+      text-align: center;
+      max-width: 480px;
+      width: 90%;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    }
+    #studify-block-page h1 {
+      margin-bottom: 16px;
+      color: #f87171;
+    }
+    #studify-block-page p {
+      margin-bottom: 20px;
+      color: #cbd5e1;
+      line-height: 1.4;
+    }
+    #studify-go-back-btn {
+      padding: 12px 24px;
+      border: none;
+      border-radius: 8px;
+      background: #3b82f6;
+      color: #ffffff;
+      font-size: 16px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    #studify-go-back-btn:hover { background: #2563eb; }
+  `;
+  document.head.appendChild(style);
   const btn = document.getElementById('studify-go-back-btn');
   if (btn) {
     btn.addEventListener('click', goBack, { once: true });
@@ -325,24 +531,17 @@ function main() {
   }
 }
 
-// Run the main function when the page is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', main);
-} else {
-  main();
-}
-
 // Smart navigation monitoring - only triggers on actual video changes
 function setupSmartNavigationMonitoring() {
   // Remove existing listener to prevent duplicates
   if (navigateListener) {
     window.removeEventListener('yt-navigate-finish', navigateListener);
   }
-  
+
   // Only listen to YouTube's official navigation event
   navigateListener = () => {
     console.log('Studify: YouTube navigation detected');
-    
+
     // Small delay to ensure page is fully loaded
     setTimeout(() => {
       // Reset analysis flag for new video
@@ -350,11 +549,60 @@ function setupSmartNavigationMonitoring() {
       main();
     }, 1000);
   };
-  
+
   window.addEventListener('yt-navigate-finish', navigateListener);
 }
 
-// Set up navigation monitoring after initial page load
-setTimeout(() => {
-  setupSmartNavigationMonitoring();
-}, 3000);
+async function init() {
+  const disabledUntil = parseInt(localStorage.getItem(DISABLED_UNTIL_KEY) || '0', 10);
+  if (Date.now() < disabledUntil) {
+    const remaining = disabledUntil - Date.now();
+    console.log('Studify: Extension paused for browsing mode');
+    setTimeout(() => {
+      localStorage.removeItem(DISABLED_UNTIL_KEY);
+      window.location.reload();
+    }, remaining);
+    return;
+  }
+
+  const studyUntil = parseInt(localStorage.getItem(STUDY_UNTIL_KEY) || '0', 10);
+  let inStudy = Date.now() < studyUntil;
+
+  if (!inStudy) {
+    const choice = await showPurposeOverlay();
+    if (choice === 'browse') {
+      const disabledUntilNew = parseInt(localStorage.getItem(DISABLED_UNTIL_KEY) || '0', 10);
+      const remaining = disabledUntilNew - Date.now();
+      if (remaining > 0) {
+        setTimeout(() => {
+          localStorage.removeItem(DISABLED_UNTIL_KEY);
+          window.location.reload();
+        }, remaining);
+      }
+      return;
+    }
+    inStudy = true;
+  }
+
+  const studyEnd = parseInt(localStorage.getItem(STUDY_UNTIL_KEY) || '0', 10);
+  const remainingStudy = studyEnd - Date.now();
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', main);
+  } else {
+    main();
+  }
+
+  setTimeout(() => {
+    setupSmartNavigationMonitoring();
+  }, 3000);
+
+  if (remainingStudy > 0) {
+    setTimeout(() => {
+      localStorage.removeItem(STUDY_UNTIL_KEY);
+      window.location.reload();
+    }, remainingStudy);
+  }
+}
+
+init();

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "description": "A Chrome extension that blocks uneducational YouTube videos by reading video categories from page source",
   "permissions": [
     "activeTab",
-    "scripting"
+    "scripting",
+    "storage"
   ],
   "host_permissions": [
     "https://www.youtube.com/*"

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     {
       "matches": ["https://www.youtube.com/*"],
       "js": ["content.js"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ],
   "action": {

--- a/popup.html
+++ b/popup.html
@@ -5,65 +5,80 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Studify</title>
     <style>
-        body {
-            width: 300px;
-            padding: 20px;
-            font-family: Arial, sans-serif;
-            background-color: #f8f9fa;
+        :root {
+            --bg: #0f172a;
+            --card-bg: #1e293b;
+            --accent: #6366f1;
+            --text: #f1f5f9;
+            --muted: #94a3b8;
+            --success: #22c55e;
+            --success-bg: #22c55e33;
+            --success-border: #22c55e66;
+            --danger: #ef4444;
+            --danger-bg: #ef444433;
+            --danger-border: #ef444466;
         }
-        
+
+        body {
+            width: 320px;
+            margin: 0;
+            padding: 20px;
+            font-family: 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+        }
+
         .header {
             text-align: center;
             margin-bottom: 20px;
         }
-        
+
         .logo {
             font-size: 24px;
-            font-weight: bold;
-            color: #007bff;
+            font-weight: 600;
+            color: var(--accent);
             margin-bottom: 5px;
         }
-        
+
         .subtitle {
-            color: #6c757d;
+            color: var(--muted);
             font-size: 14px;
         }
-        
+
         .status {
-            background-color: #d4edda;
-            border: 1px solid #c3e6cb;
-            border-radius: 6px;
+            border-radius: 8px;
             padding: 15px;
             margin-bottom: 20px;
             text-align: center;
+            border: 1px solid;
         }
-        
+
         .status.active {
-            background-color: #d4edda;
-            border-color: #c3e6cb;
-            color: #155724;
+            background: var(--success-bg);
+            border-color: var(--success-border);
+            color: var(--success);
         }
-        
+
         .status.inactive {
-            background-color: #f8d7da;
-            border-color: #f5c6cb;
-            color: #721c24;
+            background: var(--danger-bg);
+            border-color: var(--danger-border);
+            color: var(--danger);
         }
-        
+
         .info {
-            background-color: #e2e3e5;
-            border: 1px solid #d6d8db;
-            border-radius: 6px;
+            background: var(--card-bg);
+            border: 1px solid #334155;
+            border-radius: 8px;
             padding: 15px;
             font-size: 14px;
-            color: #383d41;
+            line-height: 1.4;
         }
-        
+
         .footer {
             text-align: center;
             margin-top: 20px;
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- prompt users with a full-screen overlay to choose study or browse when YouTube opens
- require exact phrase confirmation for browsing and temporarily disable filtering
- restyle all overlays and popup with a modern dark theme
- persist study sessions across reloads and offer preset duration dropdowns with incorrect phrase feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6af25b23c832392b9481094730c43