### PR TITLE
Pause video before mode prompt

### DIFF
--- a/content.js
+++ b/content.js
@@ -180,6 +180,28 @@ function pauseAllVideos() {
   document.querySelectorAll('video').forEach((v) => v.pause());
 }
 
+// Remove the mode selection overlay if it exists
+function hidePurposeOverlay() {
+  const overlay = document.getElementById('studify-purpose-overlay');
+  if (overlay) overlay.remove();
+}
+
+// Listen for mode changes from other tabs
+window.addEventListener('storage', (e) => {
+  if (e.key === STUDY_UNTIL_KEY && e.newValue) {
+    // Another tab switched to study mode - return to the homepage
+    window.location.href = 'https://www.youtube.com';
+  } else if (e.key === DISABLED_UNTIL_KEY && e.newValue) {
+    // Another tab resumed browsing - dismiss the prompt and stay paused
+    hidePurposeOverlay();
+    pauseAllVideos();
+    const remaining = parseInt(e.newValue, 10) - Date.now();
+    if (remaining > 0) {
+      scheduleModePrompt(remaining, 'browse');
+    }
+  }
+});
+
 // Show the intent prompt again after a timer expires
 function scheduleModePrompt(remaining, mode) {
   setTimeout(async () => {


### PR DESCRIPTION
## Summary
- Prevent page reloads when browse/study timers expire
- Pause the current video and show the mode selection prompt
- Redirect to YouTube home when switching from browse to study

## Testing
- `node --check content.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2646f7c88323b66c3efc25c68550