### PR TITLE
feat: allow switching to study mode from popup

### DIFF
--- a/content.js
+++ b/content.js
@@ -727,4 +727,11 @@ async function init() {
   }
 }
 
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request && request.action === 'switchToStudy') {
+    scheduleModePrompt(0, 'browse');
+    sendResponse({ status: 'ok' });
+  }
+});
+
 init();

--- a/popup.html
+++ b/popup.html
@@ -87,6 +87,16 @@
             font-size: 12px;
             color: var(--muted);
         }
+
+        .mode-btn {
+            margin-top: 10px;
+            padding: 8px 12px;
+            background: var(--accent);
+            color: var(--text);
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>

--- a/popup.js
+++ b/popup.js
@@ -12,7 +12,7 @@ function initPopup() {
         const tab = tabs[0];
         checkBrowsingMode(tab).then((state) => {
             if (state && state.remainingMs > 0) {
-                renderInactiveWithTimer(state.remainingMs);
+                renderInactiveWithTimer(state.remainingMs, tab.id);
             } else {
                 checkStudyMode(tab).then((studyState) => {
                     if (studyState && studyState.remainingMs > 0) {
@@ -138,19 +138,28 @@ function updateStatus(isYouTube) {
     }
 }
 
-function renderInactiveWithTimer(initialRemaining) {
+function renderInactiveWithTimer(initialRemaining, tabId) {
     const statusElement = document.getElementById('status');
+    statusElement.className = 'status inactive';
+    statusElement.innerHTML = `
+        <strong>🔴 Inactive</strong><br>
+        Browsing mode: <span id="studify-remaining"></span><br>
+        <button id="studify-switch-btn" class="mode-btn">Switch to Study Mode</button>
+    `;
 
-    function render(ms) {
-        statusElement.className = 'status inactive';
-        statusElement.innerHTML = `
-            <strong>🔴 Inactive</strong><br>
-            Browsing mode: ${formatRemaining(ms)} left
-        `;
-    }
+    const remainingEl = document.getElementById('studify-remaining');
+    const switchBtn = document.getElementById('studify-switch-btn');
+
+    switchBtn.addEventListener('click', () => {
+        chrome.tabs.sendMessage(tabId, { action: 'switchToStudy' });
+        window.close();
+    });
 
     let ms = initialRemaining;
-    render(ms);
+    function update() {
+        remainingEl.textContent = formatRemaining(ms);
+    }
+    update();
 
     const interval = setInterval(() => {
         ms = Math.max(0, ms - 1000);
@@ -163,7 +172,7 @@ function renderInactiveWithTimer(initialRemaining) {
             });
             return;
         }
-        render(ms);
+        update();
     }, 1000);
 }
 


### PR DESCRIPTION
## Summary
- add "Switch to Study Mode" button when browsing mode is active
- forward button action to content script to trigger study mode overlay
- style button in popup for consistency

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ab0ff0622c83238df1aaadecd2a769