### PR TITLE
Block distracting sites during study mode with user blacklist

### DIFF
--- a/blocker.js
+++ b/blocker.js
@@ -1,0 +1,63 @@
+// Studify Blocker Script
+// Blocks access to specified websites while study mode is active
+
+const DEFAULT_BLOCKED_SITES = [
+  'twitter.com',
+  'x.com',
+  'instagram.com',
+  'reddit.com',
+  'tiktok.com',
+  'twitch.tv',
+  'facebook.com'
+];
+
+const USER_BLOCK_KEY = 'studifyUserBlockedSites';
+const STUDY_UNTIL_KEY = 'studifyStudyUntil';
+
+function shouldBlock(hostname, customSites) {
+  const allSites = DEFAULT_BLOCKED_SITES.concat(customSites || []);
+  return allSites.some(site => hostname === site || hostname.endsWith('.' + site));
+}
+
+function showBlockOverlay() {
+  const render = () => {
+    document.body.innerHTML = '';
+    const overlay = document.createElement('div');
+    overlay.id = 'studify-block-overlay';
+    Object.assign(overlay.style, {
+      position: 'fixed',
+      inset: '0',
+      background: '#000',
+      color: '#fff',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '24px',
+      zIndex: '9999999',
+      fontFamily: 'Segoe UI, Roboto, sans-serif',
+      textAlign: 'center'
+    });
+    overlay.textContent = "You can't access this website while on study mode";
+    document.body.appendChild(overlay);
+  };
+  if (document.body) {
+    render();
+  } else {
+    document.addEventListener('DOMContentLoaded', render);
+  }
+}
+
+function checkBlock() {
+  chrome.storage.local.get([STUDY_UNTIL_KEY, USER_BLOCK_KEY], data => {
+    const studyUntil = parseInt(data[STUDY_UNTIL_KEY] || '0', 10);
+    if (Date.now() < studyUntil) {
+      const hostname = window.location.hostname;
+      const customSites = data[USER_BLOCK_KEY] || [];
+      if (shouldBlock(hostname, customSites)) {
+        showBlockOverlay();
+      }
+    }
+  });
+}
+
+checkBlock();

--- a/manifest.json
+++ b/manifest.json
@@ -6,15 +6,21 @@
   "permissions": [
     "activeTab",
     "scripting",
-    "storage"
+    "storage",
+    "tabs"
   ],
   "host_permissions": [
-    "https://www.youtube.com/*"
+    "<all_urls>"
   ],
   "content_scripts": [
     {
       "matches": ["https://www.youtube.com/*"],
       "js": ["content.js"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["blocker.js"],
       "run_at": "document_start"
     }
   ],

--- a/popup.html
+++ b/popup.html
@@ -81,6 +81,45 @@
             line-height: 1.4;
         }
 
+        .blacklist {
+            margin-top: 20px;
+        }
+
+        .blacklist-btn {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 10px;
+            background: var(--accent);
+            color: var(--text);
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+
+        #blocked-websites summary {
+            cursor: pointer;
+        }
+
+        #blocked-list {
+            list-style: none;
+            padding: 0;
+            margin: 5px 0 0 0;
+        }
+
+        #blocked-list li {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 4px 0;
+        }
+
+        #blocked-list button.delete-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: var(--danger);
+        }
+
         .footer {
             text-align: center;
             margin-top: 20px;
@@ -108,7 +147,17 @@
         • Removes distractive UI elements<br>
         • Helps you stay focused on learning
     </div>
-    
+
+    <div class="blacklist" id="blacklist-section" style="display:none;">
+        <button id="add-blacklist" class="blacklist-btn">Add this website to blacklist</button>
+        <details id="blocked-websites">
+            <summary>Blocked websites</summary>
+            <ul id="blocked-list">
+                <li class="empty">No websites added</li>
+            </ul>
+        </details>
+    </div>
+
     <div class="footer">
         Version 1.0.0<br>
         Made with ❤️ for students by a student

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,7 @@
 // Handles the popup interface and communicates with content scripts
 
 const STUDY_UNTIL_KEY = 'studifyStudyUntil';
+const USER_BLOCK_KEY = 'studifyUserBlockedSites';
 
 document.addEventListener('DOMContentLoaded', function() {
     initPopup();
@@ -13,22 +14,27 @@ function initPopup() {
         checkBrowsingMode(tab).then((state) => {
             if (state && state.remainingMs > 0) {
                 renderInactiveWithTimer(state.remainingMs);
+                hideBlacklistSection();
             } else {
                 checkStudyMode(tab).then((studyState) => {
                     if (studyState && studyState.remainingMs > 0) {
                         renderActiveWithTimer(studyState.remainingMs);
+                        showBlacklistSection();
                     } else {
                         const isYouTube = tab.url && tab.url.includes('youtube.com');
                         updateStatus(isYouTube);
+                        hideBlacklistSection();
                     }
                 }).catch(() => {
                     const isYouTube = tab.url && tab.url.includes('youtube.com');
                     updateStatus(isYouTube);
+                    hideBlacklistSection();
                 });
             }
         }).catch(() => {
             const isYouTube = tab.url && tab.url.includes('youtube.com');
             updateStatus(isYouTube);
+            hideBlacklistSection();
         });
     });
 }
@@ -205,4 +211,69 @@ function formatRemaining(ms) {
     if (h > 0) return `${h}h ${m}m ${s}s`;
     if (m > 0) return `${m}m ${s}s`;
     return `${s}s`;
+}
+
+function showBlacklistSection() {
+    const section = document.getElementById('blacklist-section');
+    section.style.display = 'block';
+    document.getElementById('add-blacklist').addEventListener('click', addCurrentSiteToBlacklist);
+    loadBlockedSites();
+}
+
+function hideBlacklistSection() {
+    const section = document.getElementById('blacklist-section');
+    section.style.display = 'none';
+}
+
+function addCurrentSiteToBlacklist() {
+    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+        const url = tabs[0].url || '';
+        let hostname = '';
+        try {
+            hostname = new URL(url).hostname;
+        } catch (e) {
+            return;
+        }
+        chrome.storage.local.get({ [USER_BLOCK_KEY]: [] }, (data) => {
+            const list = data[USER_BLOCK_KEY];
+            if (!list.includes(hostname)) {
+                list.push(hostname);
+                chrome.storage.local.set({ [USER_BLOCK_KEY]: list }, loadBlockedSites);
+            }
+        });
+    });
+}
+
+function loadBlockedSites() {
+    chrome.storage.local.get({ [USER_BLOCK_KEY]: [] }, (data) => {
+        const list = data[USER_BLOCK_KEY];
+        const ul = document.getElementById('blocked-list');
+        ul.innerHTML = '';
+        if (list.length === 0) {
+            const li = document.createElement('li');
+            li.className = 'empty';
+            li.textContent = 'No websites added';
+            ul.appendChild(li);
+            return;
+        }
+        list.forEach(site => {
+            const li = document.createElement('li');
+            const del = document.createElement('button');
+            del.textContent = '🗑️';
+            del.className = 'delete-btn';
+            del.addEventListener('click', () => removeBlockedSite(site));
+            const span = document.createElement('span');
+            span.textContent = site;
+            li.appendChild(del);
+            li.appendChild(span);
+            ul.appendChild(li);
+        });
+    });
+}
+
+function removeBlockedSite(site) {
+    chrome.storage.local.get({ [USER_BLOCK_KEY]: [] }, (data) => {
+        const list = data[USER_BLOCK_KEY].filter(s => s !== site);
+        chrome.storage.local.set({ [USER_BLOCK_KEY]: list }, loadBlockedSites);
+    });
 }


### PR DESCRIPTION
## Summary
- Block Twitter, Instagram, Reddit, TikTok, Twitch and Facebook when study mode is active
- Allow users to add or remove websites from a personal blacklist in the popup
- Show overlay warning on blocked sites

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab11aba6d88323b33882c18b4d0e8b