### PR TITLE
feat: allow switching to study mode from popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,51 @@
+const DEFAULT_BLOCKLIST = [
+  'facebook.com',
+  'instagram.com',
+  'twitter.com',
+  'x.com',
+  'reddit.com',
+  'tiktok.com',
+  'netflix.com'
+];
+
+function getCustomBlocklist() {
+  return new Promise((resolve) => {
+    try {
+      chrome.storage.local.get({ studifyBlocklist: [] }, (data) => {
+        const list = Array.isArray(data.studifyBlocklist) ? data.studifyBlocklist : [];
+        resolve(list);
+      });
+    } catch (e) {
+      resolve([]);
+    }
+  });
+}
+
+async function reloadBlockedTabs(excludeId) {
+  const customList = await getCustomBlocklist();
+  const allHosts = Array.from(new Set([...DEFAULT_BLOCKLIST, ...customList]));
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      if (!tab.id || tab.id === excludeId) continue;
+      const url = tab.url || '';
+      if (url.includes('youtube.com')) {
+        chrome.tabs.reload(tab.id);
+        continue;
+      }
+      for (const host of allHosts) {
+        if (url.includes(host)) {
+          chrome.tabs.reload(tab.id);
+          break;
+        }
+      }
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request && request.action === 'reloadBlocked') {
+    const excludeId = sender.tab ? sender.tab.id : undefined;
+    reloadBlockedTabs(excludeId);
+    sendResponse({ status: 'reloaded' });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -13,7 +13,9 @@ const STUDY_UNTIL_KEY = 'studifyStudyUntil';
 const STUDIFY_LOGO_URL = chrome.runtime.getURL('icons/iconCirc128.png');
 
 // Prompt the user for their intent and duration before allowing YouTube access
-function showPurposeOverlay() {
+// If an initial mode is provided, skip the mode selection prompt and go
+// straight to the duration screen for that mode.
+function showPurposeOverlay(initialMode) {
   return new Promise((resolve) => {
     const overlay = document.createElement('div');
     overlay.id = 'studify-purpose-overlay';
@@ -189,9 +191,13 @@ function showPurposeOverlay() {
       }
     }
 
-    overlay.querySelectorAll('.studify-btn').forEach((btn) => {
-      btn.addEventListener('click', () => askDuration(btn.dataset.mode));
-    });
+    if (!initialMode) {
+      overlay.querySelectorAll('.studify-btn').forEach((btn) => {
+        btn.addEventListener('click', () => askDuration(btn.dataset.mode));
+      });
+    } else {
+      askDuration(initialMode);
+    }
 
     (document.body || document.documentElement).appendChild(overlay);
   });
@@ -707,6 +713,9 @@ async function init() {
       return;
     }
     inStudy = true;
+    try {
+      chrome.runtime.sendMessage({ action: 'reloadBlocked' });
+    } catch (e) {}
   }
 
   const studyEnd = parseInt(localStorage.getItem(STUDY_UNTIL_KEY) || '0', 10);
@@ -726,5 +735,29 @@ async function init() {
     scheduleModePrompt(remainingStudy, 'study');
   }
 }
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request && request.action === 'switchToStudy') {
+    try {
+      if (chrome && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.remove(DISABLED_UNTIL_KEY);
+      }
+    } catch (e) {}
+    localStorage.removeItem(DISABLED_UNTIL_KEY);
+    pauseAllVideos();
+    showPurposeOverlay('study').then(() => {
+      try {
+        chrome.runtime.sendMessage({ action: 'reloadBlocked' });
+      } catch (e) {}
+      const studyUntilNew = parseInt(localStorage.getItem(STUDY_UNTIL_KEY) || '0', 10);
+      const remainingStudyNew = studyUntilNew - Date.now();
+      window.location.href = 'https://www.youtube.com';
+      if (remainingStudyNew > 0) {
+        scheduleModePrompt(remainingStudyNew, 'study');
+      }
+    });
+    sendResponse({ status: 'ok' });
+  }
+});
 
 init();

--- a/manifest.json
+++ b/manifest.json
@@ -5,12 +5,16 @@
   "description": "Block distracting YouTube content. Switch between Study Mode and Browse Mode for mindful, focused viewing.",
   "permissions": [
     "activeTab",
+    "tabs",
     "scripting",
     "storage"
   ],
   "host_permissions": [
     "https://www.youtube.com/*"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": ["https://www.youtube.com/*"],

--- a/popup.html
+++ b/popup.html
@@ -87,6 +87,16 @@
             font-size: 12px;
             color: var(--muted);
         }
+
+        .mode-btn {
+            margin-top: 10px;
+            padding: 8px 12px;
+            background: var(--accent);
+            color: var(--text);
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>

--- a/popup.js
+++ b/popup.js
@@ -12,7 +12,7 @@ function initPopup() {
         const tab = tabs[0];
         checkBrowsingMode(tab).then((state) => {
             if (state && state.remainingMs > 0) {
-                renderInactiveWithTimer(state.remainingMs);
+                renderInactiveWithTimer(state.remainingMs, tab.id);
             } else {
                 checkStudyMode(tab).then((studyState) => {
                     if (studyState && studyState.remainingMs > 0) {
@@ -138,19 +138,28 @@ function updateStatus(isYouTube) {
     }
 }
 
-function renderInactiveWithTimer(initialRemaining) {
+function renderInactiveWithTimer(initialRemaining, tabId) {
     const statusElement = document.getElementById('status');
+    statusElement.className = 'status inactive';
+    statusElement.innerHTML = `
+        <strong>🔴 Inactive</strong><br>
+        Browsing mode: <span id="studify-remaining"></span><br>
+        <button id="studify-switch-btn" class="mode-btn">Switch to Study Mode</button>
+    `;
 
-    function render(ms) {
-        statusElement.className = 'status inactive';
-        statusElement.innerHTML = `
-            <strong>🔴 Inactive</strong><br>
-            Browsing mode: ${formatRemaining(ms)} left
-        `;
-    }
+    const remainingEl = document.getElementById('studify-remaining');
+    const switchBtn = document.getElementById('studify-switch-btn');
+
+    switchBtn.addEventListener('click', () => {
+        chrome.tabs.sendMessage(tabId, { action: 'switchToStudy' });
+        window.close();
+    });
 
     let ms = initialRemaining;
-    render(ms);
+    function update() {
+        remainingEl.textContent = formatRemaining(ms);
+    }
+    update();
 
     const interval = setInterval(() => {
         ms = Math.max(0, ms - 1000);
@@ -163,7 +172,7 @@ function renderInactiveWithTimer(initialRemaining) {
             });
             return;
         }
-        render(ms);
+        update();
     }, 1000);
 }
 


### PR DESCRIPTION
## Summary
- add "Switch to Study Mode" button when browsing mode is active
- forward button action to content script to trigger study mode overlay
- skip mode selection prompt and start study flow immediately when switching from browse mode
- reload YouTube and blocklisted sites whenever a study session begins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ff0622c83238df1aaadecd2a769