### PR TITLE
Reload blocklisted sites when study mode activates

### DIFF
--- a/blocker.js
+++ b/blocker.js
@@ -68,3 +68,19 @@ function checkBlock() {
 }
 
 checkBlock();
+
+// Reload blocked sites when study mode starts
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && changes['studifyStudyUntil']) {
+    const newUntil = parseInt(changes['studifyStudyUntil'].newValue || '0', 10);
+    if (Date.now() < newUntil) {
+      chrome.storage.local.get(['studifyUserBlockedSites'], data => {
+        const hostname = window.location.hostname;
+        const customSites = data['studifyUserBlockedSites'] || [];
+        if (shouldBlock(hostname, customSites)) {
+          location.reload();
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Refresh custom blocklist sites when study mode begins so they are immediately blocked

## Testing
- `npm test` *(fails: no package.json)*
- `node --check blocker.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab362a9b8883239ba6e1dfb75f6e3e